### PR TITLE
Feature/reports

### DIFF
--- a/src/app/menu/components/reports/reports.component.html
+++ b/src/app/menu/components/reports/reports.component.html
@@ -18,8 +18,8 @@
       </div>
       <div class="d-flex flex-column gap-4">
         <button class="btn btn-primary btn-lg" routerLink="/menu/maid/reports/previous-report">Reporte previo</button>
-        <button class="btn btn-primary btn-lg" [disabled]="disabledPosterior">Reporte posterior</button>
-        <button class="btn btn-primary btn-lg" [disabled]="disabledFinish" (click)="onSubmit()">Enviar</button>
+        <button class="btn btn-primary btn-lg" routerLink="/menu/maid/reports/posterior-report" [disabled]="disabledPosterior">Reporte posterior</button>
+        <button class="btn btn-primary btn-lg" routerLink="/menu/maid" [disabled]="disabledFinish" (click)="onSubmit()">Enviar</button>
       </div>
       <div class=" d-flex  gap-4 justify-content-center">
         <button class="btn btn-outline-primary btn-lg" routerLink="/menu/maid">Regresar</button>

--- a/src/app/menu/components/reports/reports.component.html
+++ b/src/app/menu/components/reports/reports.component.html
@@ -17,7 +17,7 @@
         </nav>
       </div>
       <div class="d-flex flex-column gap-4">
-        <button class="btn btn-primary btn-lg" routerLink="/menu/maid/reports/previous-report">Reporte previo</button>
+        <button class="btn btn-primary btn-lg" routerLink="/menu/maid/reports/previous-report" [disabled]="disabledPrevious" [queryParams]="{id}">Reporte previo</button>
         <button class="btn btn-primary btn-lg" routerLink="/menu/maid/reports/posterior-report" [disabled]="disabledPosterior">Reporte posterior</button>
         <button class="btn btn-primary btn-lg" routerLink="/menu/maid" [disabled]="disabledFinish" (click)="onSubmit()">Enviar</button>
       </div>

--- a/src/app/menu/components/reports/reports.component.html
+++ b/src/app/menu/components/reports/reports.component.html
@@ -1,0 +1,28 @@
+<div class="container my-5">
+  <div class="mx-4 mx-sm-auto d-flex flex-column gap-5 justify-content-center col-sm-4 col-md-4 col-lg-3 lg:p-x-4">
+      <div class="d-flex flex-column gap-4">
+        <div class="text-center">
+          <img src="../../../../assets/img/activities.svg" alt="una chica checando su lista de actividades"
+              class="img-fluid" width="150">
+        </div>
+
+        <h1 class="text-center fs-2 fw-normal text-primary m-0">Reportes</h1>
+
+        <nav style="--bs-breadcrumb-divider: url(&#34;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='currentColor' class='bi bi-chevron-right' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z'/%3E%3C/svg%3E&#34;);"
+            aria-label="breadcrumb">
+            <ol class="breadcrumb mb-0">
+                <li class="breadcrumb-item active" aria-current="page"><a routerLink="/menu/maid">Actividades</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Reportes</li>
+            </ol>
+        </nav>
+      </div>
+      <div class="d-flex flex-column gap-4">
+        <button class="btn btn-primary btn-lg" routerLink="/menu/maid/reports/previous-report">Reporte previo</button>
+        <button class="btn btn-primary btn-lg" [disabled]="disabledPosterior">Reporte posterior</button>
+        <button class="btn btn-primary btn-lg" [disabled]="disabledFinish" (click)="onSubmit()">Enviar</button>
+      </div>
+      <div class=" d-flex  gap-4 justify-content-center">
+        <button class="btn btn-outline-primary btn-lg" routerLink="/menu/maid">Regresar</button>
+      </div>
+  </div>
+</div>

--- a/src/app/menu/components/reports/reports.component.spec.ts
+++ b/src/app/menu/components/reports/reports.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ReportsComponent } from './reports.component';
+
+describe('ReportsComponent', () => {
+  let component: ReportsComponent;
+  let fixture: ComponentFixture<ReportsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ReportsComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ReportsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/menu/components/reports/reports.component.ts
+++ b/src/app/menu/components/reports/reports.component.ts
@@ -20,7 +20,6 @@ export class ReportsComponent implements OnInit {
   constructor(private route:ActivatedRoute, private chambermaidReport: ChambermaidReportsService, private router: Router) { }
 
   ngOnInit(): void {
-    console.log(typeof(this.id));
     const regexp = new RegExp('^[0-9]+$')
     if(this.id ==null || !regexp.test(this.id)){
 

--- a/src/app/menu/components/reports/reports.component.ts
+++ b/src/app/menu/components/reports/reports.component.ts
@@ -1,0 +1,47 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { ChambermaidReportsService } from '../../services/chambermaid-reports.service';
+import { Report } from '../../interfaces/report.interface';
+
+@Component({
+  selector: 'app-reports',
+  templateUrl: './reports.component.html',
+  styleUrls: ['./reports.component.scss']
+})
+export class ReportsComponent implements OnInit {
+
+  id: number = this.route.snapshot.queryParams['id'];
+  report!: Report;
+  statusPosteriorReport!:boolean;
+  disabledPosterior : boolean = true;
+  disabledFinish : boolean = true;
+
+  constructor(private route:ActivatedRoute, private chambermaidReport: ChambermaidReportsService, private router: Router) { }
+
+  ngOnInit(): void {
+    this.chambermaidReport.getReport(this.id).subscribe(data => {
+      this.report=data;
+      console.log(this.report);
+      let statusPrevious = this.report.reports.previousReport.active;
+      let statusPost = this.report.reports.posteriorReport.active;
+
+      if(statusPrevious){
+        this.disabledPosterior = false;
+      }
+
+      if(statusPrevious && statusPost){
+        this.disabledFinish = false;
+      }
+
+    })
+  }
+
+  onSubmit(){
+    this.chambermaidReport.updatedStatusActivity(this.report).subscribe(
+      resp => {
+        this.router.navigate([`/menu/maid/`]);
+      }
+    )
+  }
+
+}

--- a/src/app/menu/components/reports/reports.component.ts
+++ b/src/app/menu/components/reports/reports.component.ts
@@ -10,30 +10,46 @@ import { Report } from '../../interfaces/report.interface';
 })
 export class ReportsComponent implements OnInit {
 
-  id: number = this.route.snapshot.queryParams['id'];
+  id: string = this.route.snapshot.queryParams['id'];
   report!: Report;
   statusPosteriorReport!:boolean;
+  disabledPrevious: boolean=true;
   disabledPosterior : boolean = true;
   disabledFinish : boolean = true;
 
   constructor(private route:ActivatedRoute, private chambermaidReport: ChambermaidReportsService, private router: Router) { }
 
   ngOnInit(): void {
+    console.log(typeof(this.id));
+    const regexp = new RegExp('^[0-9]+$')
+    if(this.id ==null || !regexp.test(this.id)){
+
+      this.router.navigateByUrl('/menu/maid');
+    }
+
     this.chambermaidReport.getReport(this.id).subscribe(data => {
       this.report=data;
-      console.log(this.report);
+
       let statusPrevious = this.report.reports.previousReport.active;
       let statusPost = this.report.reports.posteriorReport.active;
 
-      if(statusPrevious){
-        this.disabledPosterior = false;
-      }
-
-      if(statusPrevious && statusPost){
-        this.disabledFinish = false;
-      }
-
+      this.checkStatusReports(statusPrevious,statusPost);
     })
+  }
+
+  checkStatusReports(statusPrev: boolean, statusPost: boolean){
+
+    if(!statusPrev){
+      this.disabledPrevious = false;
+      this.disabledPosterior = true;
+    }else if(statusPost){
+      this.disabledFinish = false;
+      this.disabledPrevious= true;
+      this.disabledPosterior = true;
+    }else{
+      this.disabledPrevious=true;
+      this.disabledPosterior=false;
+    }
   }
 
   onSubmit(){

--- a/src/app/menu/interfaces/report.interface.ts
+++ b/src/app/menu/interfaces/report.interface.ts
@@ -1,0 +1,33 @@
+export interface BodyGetReport {
+  status: number;
+  message: string;
+  body: Report;
+}
+
+export interface Report {
+  id: number;
+  dateAssigned: string;
+  title: string;
+  description: string;
+  status: string;
+  hourStart: string;
+  hourEnd: string;
+  reports: Reports;
+}
+
+export interface Reports {
+  previousReport: PreviousReport;
+  posteriorReport: PosteriorReport;
+}
+
+export interface PosteriorReport {
+  description: string;
+  dirtyClothes: string;
+  active: boolean;
+}
+
+export interface PreviousReport {
+  description: string;
+  dirtLevel: number;
+  active: boolean;
+}

--- a/src/app/menu/menu-routing.module.ts
+++ b/src/app/menu/menu-routing.module.ts
@@ -5,6 +5,7 @@ import { MenuComponent } from './menu.component';
 import { MyProfileComponent } from './components/my-profile/my-profile.component';
 import { MenuGuard } from '../core/guards/menu.guard';
 import { MenuChildGuard } from '../core/guards/menu-child.guard';
+import { ReportsComponent } from './components/reports/reports.component';
 
 const routes: Routes = [
   {
@@ -13,10 +14,13 @@ const routes: Routes = [
       {
         path:'maid', component: ChambermaidMenuComponent, canActivateChild: [MenuChildGuard]
       },
+      {
+        path: 'maid/reports', component: ReportsComponent, canActivateChild: [MenuChildGuard]
+      },
+      {
+        path: 'my-profile', component: MyProfileComponent, canActivateChild: [MenuChildGuard]
+      }
     ]
-  },
-  {
-    path: 'my-profile', component: MyProfileComponent, canActivate: [MenuGuard]
   }
 ];
 

--- a/src/app/menu/menu.module.ts
+++ b/src/app/menu/menu.module.ts
@@ -7,13 +7,15 @@ import { MenuComponent } from './menu.component';
 import { ChambermaidMenuComponent } from './components/chambermaid-menu/chambermaid-menu.component';
 import { ChambermaidActivitiesComponent } from './components/chambermaid-activities/chambermaid-activities.component';
 import { MyProfileComponent } from './components/my-profile/my-profile.component';
+import { ReportsComponent } from './components/reports/reports.component';
 
 @NgModule({
   declarations: [
     MenuComponent,
     ChambermaidMenuComponent,
     ChambermaidActivitiesComponent,
-    MyProfileComponent
+    MyProfileComponent,
+    ReportsComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/menu/services/chambermaid-reports.service.spec.ts
+++ b/src/app/menu/services/chambermaid-reports.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ChambermaidReportsService } from './chambermaid-reports.service';
+
+describe('ChambermaidReportsService', () => {
+  let service: ChambermaidReportsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ChambermaidReportsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/menu/services/chambermaid-reports.service.ts
+++ b/src/app/menu/services/chambermaid-reports.service.ts
@@ -15,7 +15,7 @@ export class ChambermaidReportsService {
 
   constructor(private httpClient: HttpClient) { }
 
-  getReport(id:number): Observable<Report> {
+  getReport(id:string): Observable<Report> {
     return this.httpClient.get<BodyGetReport>(`${this.URL}maid/activity/${id}`).pipe(
       map((response) => {
         return response.body;

--- a/src/app/menu/services/chambermaid-reports.service.ts
+++ b/src/app/menu/services/chambermaid-reports.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { environment } from 'src/environments/environment';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { BodyGetReport, Report } from '../interfaces/report.interface';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ChambermaidReportsService {
+
+  private readonly URL: string = environment.URL;
+
+
+  constructor(private httpClient: HttpClient) { }
+
+  getReport(id:number): Observable<Report> {
+    return this.httpClient.get<BodyGetReport>(`${this.URL}maid/activity/${id}`).pipe(
+      map((response) => {
+        return response.body;
+      })
+    );
+  }
+
+  updatedStatusActivity(report: Report){
+    const id = {
+      id: report.id
+    }
+    return this.httpClient.patch(`${this.URL}maid/activity`,id);
+  }
+}


### PR DESCRIPTION
Agregado componente Reports que permite al usuario ver sus opciones para requisitar sus formularios de reporte previo y posterior y enviarlos.


* El botón de Reporte previo estará activo siempre, pues es el primer formulario.

<img width="301" alt="image" src="https://user-images.githubusercontent.com/99765304/170115870-aba40238-631d-4caf-910d-40caf7270dd6.png">

* Cuando se haya requisitado el primer formulario y se hayan guardado cambios se habilitará el botón de Reporte posterior.

<img width="299" alt="image" src="https://user-images.githubusercontent.com/99765304/170117000-205ad8ae-37ac-493d-bdef-2aa4ed293991.png">

* Ya requisitados ambos reportes podrá darle clic al botón de Enviar.

<img width="300" alt="image" src="https://user-images.githubusercontent.com/99765304/170117260-e26031a4-61f8-45ba-b7f2-f42eb6f95602.png">

* También se agrega un botón para regresar al panel anterior (Actividades) y una ruta de migas con función de navegación a apartados anteriores.




