### PR TITLE
Feature/posterior report

### DIFF
--- a/src/app/menu/components/posterior-report/posterior-report.component.html
+++ b/src/app/menu/components/posterior-report/posterior-report.component.html
@@ -1,0 +1,74 @@
+<div class="container my-5">
+  <div class="mx-4 mx-sm-auto d-flex flex-column gap-4 justify-content-center col-sm-7 col-md-6 col-lg-4 lg:p-x-6">
+
+    <h1 class="text-center fs-2 fw-normal text-primary m-0">Reporte posterior</h1>
+
+    <nav
+      style="--bs-breadcrumb-divider: url(&#34;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='currentColor' class='bi bi-chevron-right' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z'/%3E%3C/svg%3E&#34;);"
+      aria-label="breadcrumb">
+      <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item"><a routerLink="/menu/maid" [queryParams]="{page: '1'}">Actividades</a></li>
+        <li class="breadcrumb-item"><a routerLink="/menu/reports" [queryParams]="{id}">Reportes</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Reporte posterior</li>
+      </ol>
+    </nav>
+
+    <p>Fecha de inspección: {{myDate | date: 'EEEE, MMMM d, y' }}</p>
+
+    <form action="" class="d-flex flex-column gap-4 needs-validation css-form" [formGroup]="posteriorReport"
+      (ngSubmit)="submitForm()">
+
+      <div>
+        <label for="video" class="form-label">Estado de amenidades y blancos</label>
+        <button class="btn btn-outline-primary" routerLink="/maid/reports/video" [queryParams]="{id, type: 'posterior'}"><i
+            class="bi bi-camera-video-fill"></i> Tomar video</button>
+            <div class="text-danger small" *ngIf="videoError">
+              *El video es requerido.
+            </div>
+      </div>
+      <div>
+        <label for="description" class="form-label">Desperfectos o faltantes</label>
+        <textarea class="form-control" name="description" id="description" aria-label="With textarea"
+          formControlName="description"></textarea>
+
+        <div class="text-danger small"
+          *ngIf="posteriorReport.get('description')?.hasError('maxlength')&& posteriorReport.get('description')?.touched">
+          *La descripción no debe contener mas de 100 caracteres
+        </div>
+      </div>
+
+      <div>
+        <button type="button" class="btn btn-outline-primary" routerLink="/maid/reports/camera" [queryParams]="{id, type: 'posterior'}"><i class="bi bi-camera-fill"></i> Tomar fotos (máximo 5)</button>
+        <div class="text-danger small" *ngIf="imageError">
+          *Mínimo una imagen es requerida.
+        </div>
+      </div>
+
+      <div>
+        <button class="btn btn-outline-primary "><i class="bi bi-eye-fill"></i> Ver fotos</button>
+      </div>
+
+      <div>
+        <label for="dirtyClothes" class="form-label">Ropa sucia</label>
+        <textarea class="form-control" name="dirtyClothes" id="dirtyClothes" aria-label="With textarea"
+          formControlName="dirtyClothes"></textarea>
+
+        <div class="text-danger small"
+          *ngIf="posteriorReport.get('dirtyClothes')?.hasError('maxlength')&& posteriorReport.get('dirtyClothes')?.touched">
+          *La descripción no debe contener mas de 100 caracteres
+        </div>
+        <div class="text-danger small"
+        *ngIf="posteriorReport.get('dirtyClothes')?.hasError('required')&& posteriorReport.get('dirtyClothes')?.touched">
+        *La descripción es requerida
+      </div>
+      </div>
+
+      <div class="d-grid gap-4">
+        <input [disabled]="posteriorReport.invalid" type="submit" value="Guardar" class="btn btn-lg btn-primary shadow-sm">
+        <button routerLink="/menu/reports" [queryParams]="{id}"
+          class="btn btn-lg btn-outline-primary shadow-sm">Cancelar</button>
+      </div>
+    </form>
+
+  </div>
+</div>

--- a/src/app/menu/components/posterior-report/posterior-report.component.html
+++ b/src/app/menu/components/posterior-report/posterior-report.component.html
@@ -19,7 +19,7 @@
       (ngSubmit)="submitForm()">
 
       <div>
-        <label for="video" class="form-label">Estado de amenidades y blancos</label>
+        <label for="video" class="form-label">Resultado final</label><br>
         <button class="btn btn-outline-primary" routerLink="/maid/reports/video" [queryParams]="{id, type: 'posterior'}"><i
             class="bi bi-camera-video-fill"></i> Tomar video</button>
             <div class="text-danger small" *ngIf="videoError">
@@ -27,7 +27,7 @@
             </div>
       </div>
       <div>
-        <label for="description" class="form-label">Desperfectos o faltantes</label>
+        <label for="description" class="form-label">Objetos olvidados</label>
         <textarea class="form-control" name="description" id="description" aria-label="With textarea"
           formControlName="description"></textarea>
 
@@ -38,6 +38,7 @@
       </div>
 
       <div>
+        <label for="camera" class="form-label">Amenidades colocadas</label>
         <button type="button" class="btn btn-outline-primary" routerLink="/maid/reports/camera" [queryParams]="{id, type: 'posterior'}"><i class="bi bi-camera-fill"></i> Tomar fotos (máximo 5)</button>
         <div class="text-danger small" *ngIf="imageError">
           *Mínimo una imagen es requerida.

--- a/src/app/menu/components/posterior-report/posterior-report.component.html
+++ b/src/app/menu/components/posterior-report/posterior-report.component.html
@@ -7,15 +7,15 @@
       style="--bs-breadcrumb-divider: url(&#34;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='currentColor' class='bi bi-chevron-right' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z'/%3E%3C/svg%3E&#34;);"
       aria-label="breadcrumb">
       <ol class="breadcrumb mb-0">
-        <li class="breadcrumb-item"><a routerLink="/menu/maid" [queryParams]="{page: '1'}">Actividades</a></li>
-        <li class="breadcrumb-item"><a routerLink="/menu/reports" [queryParams]="{id}">Reportes</a></li>
+        <li class="breadcrumb-item"><a routerLink="/maid/menu" [queryParams]="{page: '1'}">Actividades</a></li>
+        <li class="breadcrumb-item"><a routerLink="/maid/reports" [queryParams]="{id}">Reportes</a></li>
         <li class="breadcrumb-item active" aria-current="page">Reporte posterior</li>
       </ol>
     </nav>
 
     <p>Fecha de inspección: {{myDate | date: 'EEEE, MMMM d, y' }}</p>
 
-    <form action="" class="d-flex flex-column gap-4 needs-validation css-form" [formGroup]="posteriorReport"
+    <form class="d-flex flex-column gap-4 needs-validation css-form" [formGroup]="posteriorReport"
       (ngSubmit)="submitForm()">
 
       <div>
@@ -46,7 +46,7 @@
       </div>
 
       <div>
-        <button class="btn btn-outline-primary "><i class="bi bi-eye-fill"></i> Ver fotos</button>
+        <button type="button" class="btn btn-outline-primary "><i class="bi bi-eye-fill"></i> Ver fotos</button>
       </div>
 
       <div>

--- a/src/app/menu/components/posterior-report/posterior-report.component.scss
+++ b/src/app/menu/components/posterior-report/posterior-report.component.scss
@@ -1,0 +1,7 @@
+.css-form textarea.ng-invalid.ng-touched {
+  border : 1px solid red;
+}
+
+.css-form textarea.ng-valid.ng-touched {
+  border :  1px solid green;
+}

--- a/src/app/menu/components/posterior-report/posterior-report.component.spec.ts
+++ b/src/app/menu/components/posterior-report/posterior-report.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PosteriorReportComponent } from './posterior-report.component';
+
+describe('PosteriorReportComponent', () => {
+  let component: PosteriorReportComponent;
+  let fixture: ComponentFixture<PosteriorReportComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ PosteriorReportComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PosteriorReportComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/menu/components/posterior-report/posterior-report.component.ts
+++ b/src/app/menu/components/posterior-report/posterior-report.component.ts
@@ -1,0 +1,77 @@
+import { Component, OnInit } from '@angular/core';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { PosteriorReport } from '../../interfaces/posteriorReport.interface';
+import { ChambermaidActivitiesService } from '../../services/chambermaid-activities.service';
+import { Activity } from '../../interfaces/activity.interface';
+import { ActivatedRoute, Router } from '@angular/router';
+import { VideoCaptureService } from '../../services/video-capture.service';
+import { ToastrService } from 'ngx-toastr';
+
+@Component({
+  selector: 'app-posterior-report',
+  templateUrl: './posterior-report.component.html',
+  styleUrls: ['./posterior-report.component.scss']
+})
+export class PosteriorReportComponent implements OnInit {
+
+  myDate = new Date();
+  activities!: Array<Activity>;
+  videoError: boolean = false;
+  imageError: boolean = false;
+  id: string = this.route.snapshot.queryParams['id'];
+
+  posteriorReport: FormGroup = this.fb.group({
+    description: ['', [Validators.maxLength(100)]],
+    dirtyClothes: ['', [Validators.maxLength(100), Validators.required]]
+  });
+
+  constructor(
+    private fb: FormBuilder,
+    private ChambermaidActivitiesService: ChambermaidActivitiesService,
+    private route: ActivatedRoute,
+    private router: Router,
+    private toastService: ToastrService,
+    private videoService: VideoCaptureService
+
+  ) {}
+
+  ngOnInit(): void {
+    const regexp = new RegExp('^[0-9]+$');
+    if (this.id == null || !regexp.test(this.id)) {
+      this.toastService.warning('La página solicitada no existe. 😥');
+      this.router.navigate(['/maid/menu'], {queryParams: { page: 1 }});
+    }
+  }
+
+  submitForm() {
+    const posteriorReport: PosteriorReport = {
+      description: this.posteriorReport.get('description')?.value,
+      dirtyClothes: this.posteriorReport.get('dirtyClothes')?.value
+    };
+    let formData: FormData = new FormData();
+    const video = this.videoService.getVideo();
+    const images = this.videoService.getImages();
+    if(video){
+      this.videoError = false;
+      if(images.length > 0){
+        this.imageError = false;
+        formData.append("description", posteriorReport.description);
+        formData.append("dirtyClothes", posteriorReport.dirtyClothes);
+        formData.append("video", video);
+        for(let image of images){
+          formData.append("images", image);
+        }
+        this.ChambermaidActivitiesService.posteriorReportCreate(formData, this.id).subscribe(
+          resp => {
+            this.router.navigate(['/maid/reports'],{ queryParams: {id:this.id}});
+          }
+        )
+      }else{
+        this.imageError = true;
+      }
+
+    }else{
+      this.videoError = true;
+    }
+  }
+}

--- a/src/app/menu/components/video-file/video-file.component.html
+++ b/src/app/menu/components/video-file/video-file.component.html
@@ -8,14 +8,14 @@
             <li class="breadcrumb-item"><a>Inicio</a></li>
             <li class="breadcrumb-item" aria-current="page"><a [routerLink]="['/maid/menu']" [queryParams]="{page: '1'}">Actividades</a></li>
             <li class="breadcrumb-item" aria-current="page"><a [routerLink]="['/maid/reports']" [queryParams]="{id}">Reportes</a></li>
-            <li class="breadcrumb-item" aria-current="page"><a [routerLink]="['/maid/reports/previous-report']" [queryParams]="{id}">Reporte Previo</a></li>
+            <li class="breadcrumb-item" aria-current="page"><a [routerLink]="['/maid/reports/' + typeReport]" [queryParams]="{id}">{{ typeReport | typeReport }}</a></li>
             <li class="breadcrumb-item active" aria-current="page"><a>Video</a></li>
         </ol>
     </nav>
 
     <div>
-        <a href="" [routerLink]="['/maid/reports/previous-report']" [queryParams]="{id}" class="text-primary text-decoration-none"><i class="bi bi-arrow-left"></i> Regresar</a>
-    </div>
+      <a [routerLink]="['/maid/reports/' + typeReport]" [queryParams]="{id}" class="text-primary text-decoration-none"><i class="bi bi-arrow-left"></i> Regresar</a>
+  </div>
 
     <app-video-capture (video)="getVideo($event)"></app-video-capture>
 </div>

--- a/src/app/menu/interfaces/posteriorReport.interface.ts
+++ b/src/app/menu/interfaces/posteriorReport.interface.ts
@@ -1,0 +1,6 @@
+export interface PosteriorReport {
+  video?: any;
+  description: string;
+  images?: any[];
+  dirtyClothes: string;
+}

--- a/src/app/menu/interfaces/posteriorReport.interface.ts
+++ b/src/app/menu/interfaces/posteriorReport.interface.ts
@@ -1,6 +1,4 @@
 export interface PosteriorReport {
-  video?: any;
   description: string;
-  images?: any[];
   dirtyClothes: string;
 }

--- a/src/app/menu/interfaces/previousReport.interface.ts
+++ b/src/app/menu/interfaces/previousReport.interface.ts
@@ -1,6 +1,4 @@
 export interface PreviousReport {
-  video?: any;
   description: string;
-  images?: any[];
   dirtLevel: string;
 }

--- a/src/app/menu/menu-routing.module.ts
+++ b/src/app/menu/menu-routing.module.ts
@@ -9,6 +9,7 @@ import { VideoFileComponent } from './components/video-file/video-file.component
 import { PreviousReportComponent } from './components/previous-report/previous-report.component';
 import { ReportsComponent } from './components/reports/reports.component';
 import { CameraFilesComponent } from './components/camera-files/camera-files.component';
+import { PosteriorReportComponent } from './components/posterior-report/posterior-report.component';
 
 const routes: Routes = [
   {
@@ -27,6 +28,9 @@ const routes: Routes = [
       },
       {
         path: 'reports/previous-report', component: PreviousReportComponent, canActivateChild: [MenuChildGuard]
+      },
+      {
+        path: 'reports/posterior-report', component: PosteriorReportComponent, canActivateChild: [MenuChildGuard]
       },
       {
         path:'reports/video', component: VideoFileComponent, canActivateChild: [MenuChildGuard]

--- a/src/app/menu/menu.module.ts
+++ b/src/app/menu/menu.module.ts
@@ -12,6 +12,7 @@ import { VideoFileComponent } from './components/video-file/video-file.component
 import { PreviousReportComponent } from './components/previous-report/previous-report.component';
 import { ReportsComponent } from './components/reports/reports.component';
 import { CameraFilesComponent } from './components/camera-files/camera-files.component';
+import { PosteriorReportComponent } from './components/posterior-report/posterior-report.component';
 
 @NgModule({
   declarations: [
@@ -22,7 +23,8 @@ import { CameraFilesComponent } from './components/camera-files/camera-files.com
     VideoFileComponent,
     PreviousReportComponent,
     ReportsComponent,
-    CameraFilesComponent
+    CameraFilesComponent,
+    PosteriorReportComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/menu/services/chambermaid-activities.service.ts
+++ b/src/app/menu/services/chambermaid-activities.service.ts
@@ -32,4 +32,13 @@ export class ChambermaidActivitiesService {
       tap(() => this.toastService.success('El reporte previo se guardo correctamente.'))
     );
   }
+
+  posteriorReportCreate(posteriorReport: FormData, id:string){
+    const query = {
+      id
+    }
+    return this.httpClient.patch(`${this.URL}posterior-report/update/`, posteriorReport,{params:query}).pipe(
+      tap(() => this.toastService.success('El reporte posterior se guardo correctamente.'))
+    );
+  }
 }


### PR DESCRIPTION
Se creó una pantalla de Reporte posterior para registrar las condiciones posteriores a la limpieza de la habitación.
![localhost_4200_maid_reports_posterior-report_id=2(iPhone SE)](https://user-images.githubusercontent.com/79349436/170892302-781bc639-79e7-4550-9e42-3fcc1c73e7c1.png)

El usuario podrá navegar en pantallas anteriores a través de una ruta de migas.
El usuario podrá ver la Fecha de inspección
El usuario dispondrá de un formulario en donde podrá requisitar la información solicitada con respecto a las condiciones de la habitación:

- adjuntar un video (Requerido de máximo 15 segundos)
- fotografías como evidencia (Requerido, máximo 5 fotografías)
- breve descripción de los objetos olvidados (Opcional, máximo 100 caracteres)
- Descripción de ropa sucia (Requerido, máximo 100 caracteres)
- un botón para visualizar las fotografías tomadas

![localhost_4200_maid_reports_posterior-report_id=2(iPhone SE) (1)](https://user-images.githubusercontent.com/79349436/170892346-98673ecd-e4c5-47f5-8b09-c13eb677a987.png)

Cuando el formulario esté correctamente requisitado, el botón guardar se habilitará y al hacer clic sobre él se mandará la información a la api

![localhost_4200_maid_reports_posterior-report_id=2(iPhone SE) (3)](https://user-images.githubusercontent.com/79349436/170892450-358e9dd4-e50e-4f93-b23f-dc673ebca83a.png)




