### PR TITLE
Feature/housekeeper reports

### DIFF
--- a/src/app/housekeeper/components/housekeeper-reports/housekeeper-reports.component.html
+++ b/src/app/housekeeper/components/housekeeper-reports/housekeeper-reports.component.html
@@ -11,6 +11,7 @@
         <nav style="--bs-breadcrumb-divider: url(&#34;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='currentColor' class='bi bi-chevron-right' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z'/%3E%3C/svg%3E&#34;);"
             aria-label="breadcrumb">
             <ol class="breadcrumb mb-0">
+                <li class="breadcrumb-item active" aria-current="page"><a routerLink="/housekeeper/menu" [queryParams]="{page: '1'}">Menú</a></li>
                 <li class="breadcrumb-item active" aria-current="page"><a routerLink="/housekeeper/activities" [queryParams]="{page: '1'}">Actividades</a></li>
                 <li class="breadcrumb-item active" aria-current="page">Reportes</li>
             </ol>

--- a/src/app/housekeeper/components/housekeeper-reports/housekeeper-reports.component.html
+++ b/src/app/housekeeper/components/housekeeper-reports/housekeeper-reports.component.html
@@ -1,0 +1,28 @@
+<div class="container my-5">
+  <div class="mx-4 mx-sm-auto d-flex flex-column gap-5 justify-content-center col-sm-4 col-md-4 col-lg-3 lg:p-x-4">
+      <div class="d-flex flex-column gap-4">
+        <div class="text-center">
+          <img src="../../../../assets/img/activities.svg" alt="una chica checando su lista de actividades"
+              class="img-fluid" width="150">
+        </div>
+
+        <h1 class="text-center fs-2 fw-normal text-primary m-0">Reportes</h1>
+
+        <nav style="--bs-breadcrumb-divider: url(&#34;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='currentColor' class='bi bi-chevron-right' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z'/%3E%3C/svg%3E&#34;);"
+            aria-label="breadcrumb">
+            <ol class="breadcrumb mb-0">
+                <li class="breadcrumb-item active" aria-current="page"><a routerLink="/housekeeper/activities" [queryParams]="{page: '1'}">Actividades</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Reportes</li>
+            </ol>
+        </nav>
+      </div>
+      <div class="d-flex flex-column gap-4">
+        <button class="btn btn-primary btn-lg" routerLink="previous-report" [disabled]="disabledPrevious" [queryParams]="{id}">Reporte previo</button>
+        <button class="btn btn-primary btn-lg" routerLink="posterior-report" [disabled]="disabledPosterior" [queryParams]="{id}">Reporte posterior</button>
+        <button class="btn btn-primary btn-lg" [disabled]="disabledFinish" (click)="onSubmit()">Enviar</button>
+      </div>
+      <div class=" d-flex  gap-4 justify-content-center">
+        <button class="btn btn-outline-primary btn-lg" routerLink="/housekeeper/activities" [queryParams]="{page: '1'}">Regresar</button>
+      </div>
+  </div>
+</div>

--- a/src/app/housekeeper/components/housekeeper-reports/housekeeper-reports.component.spec.ts
+++ b/src/app/housekeeper/components/housekeeper-reports/housekeeper-reports.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HousekeeperReportsComponent } from './housekeeper-reports.component';
+
+describe('HousekeeperReportsComponent', () => {
+  let component: HousekeeperReportsComponent;
+  let fixture: ComponentFixture<HousekeeperReportsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ HousekeeperReportsComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HousekeeperReportsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/housekeeper/components/housekeeper-reports/housekeeper-reports.component.ts
+++ b/src/app/housekeeper/components/housekeeper-reports/housekeeper-reports.component.ts
@@ -1,0 +1,64 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { ToastrService } from 'ngx-toastr';
+import { HousekeeperReportsService } from '../../services/housekeeper-reports.service';
+import { Report } from '../../interfaces/housekeeperReport.interface';
+
+@Component({
+  selector: 'app-housekeeper-reports',
+  templateUrl: './housekeeper-reports.component.html',
+  styleUrls: ['./housekeeper-reports.component.scss']
+})
+export class HousekeeperReportsComponent implements OnInit {
+
+  id: string = this.route.snapshot.queryParams['id'];
+  report!: Report;
+  disabledPrevious: Boolean = true;
+  disabledPosterior : boolean = true;
+  disabledFinish : boolean = true;
+
+  constructor(private route: ActivatedRoute, private router: Router,
+              private toastService: ToastrService, private housekeeperReport: HousekeeperReportsService) { }
+
+  ngOnInit(): void {
+    const regexp = new RegExp('^[0-9]+$')
+    if(this.id == null || !regexp.test(this.id)){
+      this.toastService.warning('La página solicitada no existe. 😥');
+      this.router.navigate(['/housekeeper/activities'], {queryParams: { page: 1 }} );
+    }else{
+      this.housekeeperReport.getReportHousekeeper(this.id).subscribe(data => {
+        this.report=data;
+        console.log(this.report)
+
+        let statusPrevious = this.report.reports.previousReport.active;
+        let statusPost = this.report.reports.posteriorReport.active;
+
+        this.checkStatusReports(statusPrevious,statusPost);
+      })
+    }
+  }
+
+  checkStatusReports(statusPrev: boolean, statusPost: boolean){
+
+    if(!statusPrev){
+      this.disabledPrevious = false;
+      this.disabledPosterior = true;
+    }else if(statusPost){
+      this.disabledFinish = false;
+      this.disabledPrevious= true;
+      this.disabledPosterior = true;
+    }else{
+      this.disabledPrevious=true;
+      this.disabledPosterior=false;
+    }
+  }
+
+  onSubmit(){
+    this.housekeeperReport.updatedStatusActivity(this.report).subscribe(
+      resp => {
+        this.router.navigate(['/housekeeper/activities'], {queryParams: {page: 1 }});
+      }
+    )
+  }
+
+}

--- a/src/app/housekeeper/components/housekeeper-reports/housekeeper-reports.component.ts
+++ b/src/app/housekeeper/components/housekeeper-reports/housekeeper-reports.component.ts
@@ -28,7 +28,6 @@ export class HousekeeperReportsComponent implements OnInit {
     }else{
       this.housekeeperReport.getReportHousekeeper(this.id).subscribe(data => {
         this.report=data;
-        console.log(this.report)
 
         let statusPrevious = this.report.reports.previousReport.active;
         let statusPost = this.report.reports.posteriorReport.active;

--- a/src/app/housekeeper/housekeeper-routing.module.ts
+++ b/src/app/housekeeper/housekeeper-routing.module.ts
@@ -4,6 +4,7 @@ import { HousekeeperComponent } from './housekeeper.component';
 import { HousekeeperModulesComponent } from './components/housekeeper-modules/housekeeper-modules.component';
 import { MenuGuard } from '../core/guards/menu.guard';
 import { MenuChildGuard } from '../core/guards/menu-child.guard';
+import { HousekeeperReportsComponent } from './components/housekeeper-reports/housekeeper-reports.component';
 
 const routes: Routes = [
   {
@@ -15,7 +16,10 @@ const routes: Routes = [
     path: '', component: HousekeeperComponent, canActivate: [MenuGuard],
     children: [
       {
-          path: 'menu', component: HousekeeperModulesComponent, canActivateChild: [MenuChildGuard]
+        path: 'menu', component: HousekeeperModulesComponent, canActivateChild: [MenuChildGuard]
+      },
+      {
+        path: 'reports', component: HousekeeperReportsComponent, canActivateChild: [MenuChildGuard]
       }
     ]
   }

--- a/src/app/housekeeper/housekeeper.module.ts
+++ b/src/app/housekeeper/housekeeper.module.ts
@@ -6,13 +6,15 @@ import { HousekeeperRoutingModule } from './housekeeper-routing.module';
 import { HousekeeperComponent } from './housekeeper.component';
 import { HousekeeperModulesComponent } from './components/housekeeper-modules/housekeeper-modules.component';
 import { SharedModule } from '../shared/shared.module';
+import { HousekeeperReportsComponent } from './components/housekeeper-reports/housekeeper-reports.component';
 
 
 
 @NgModule({
   declarations: [
     HousekeeperComponent,
-    HousekeeperModulesComponent
+    HousekeeperModulesComponent,
+    HousekeeperReportsComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/housekeeper/interfaces/housekeeperReport.interface.ts
+++ b/src/app/housekeeper/interfaces/housekeeperReport.interface.ts
@@ -1,0 +1,32 @@
+export interface HousekeeperBodyGetReport {
+  status: number;
+  message: string;
+  body: Report;
+}
+
+export interface Report {
+  id: number;
+  dateAssigned: string;
+  title: string;
+  description: string;
+  status: string;
+  hourStart?: any;
+  hourEnd?: any;
+  reports: Reports;
+}
+
+export interface Reports {
+  previousReport: PreviousReport;
+  posteriorReport: PosteriorReport;
+}
+
+export interface PosteriorReport {
+  description?: any;
+  active: boolean;
+}
+
+export interface PreviousReport {
+  description?: any;
+  dirtLevel?: any;
+  active: boolean;
+}

--- a/src/app/housekeeper/services/housekeeper-reports.service.spec.ts
+++ b/src/app/housekeeper/services/housekeeper-reports.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { HousekeeperReportsService } from './housekeeper-reports.service';
+
+describe('HousekeeperReportsService', () => {
+  let service: HousekeeperReportsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(HousekeeperReportsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/housekeeper/services/housekeeper-reports.service.ts
+++ b/src/app/housekeeper/services/housekeeper-reports.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { environment } from '../../../environments/environment';
+import { Observable } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
+import { HousekeeperBodyGetReport, Report } from '../interfaces/housekeeperReport.interface';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class HousekeeperReportsService {
+
+  private readonly URL: string = environment.URL;
+
+  constructor(private httpClient: HttpClient) { }
+
+  getReportHousekeeper(id: string): Observable<Report>{
+    return this.httpClient.get<HousekeeperBodyGetReport>(`${this.URL}housekeeper/activity/${id}`).pipe(
+      map((response) => {
+        return response.body;
+      })
+    );
+  }
+
+  updatedStatusActivity(report: Report){
+    const id= {
+      id: report.id
+    }
+    return this.httpClient.patch(`${this.URL}housekeeper/activity`,id)
+  }
+}

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,7 @@
 
 export const environment = {
   production: false,
-  URL : 'https://hotel-api-unsij.herokuapp.com/'
+  URL: ''
 };
 
 /*

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,7 @@
 
 export const environment = {
   production: false,
-  URL: ''
+  URL : 'https://hotel-api-unsij.herokuapp.com/'
 };
 
 /*

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,5 +1,5 @@
 // _variables.scss
 $primary:#733FC8;
-$success: #49556B;
+$success: #198754;
 $dark: #18202D;
-$secondary: #EDF2F8;
+$secondary: #adb5bd;

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -1,4 +1,4 @@
 /* You can add global styles to this file, and also import other style files */
-// @import "variables";
+@import "variables";
 @import "../../node_modules/bootstrap/scss/bootstrap.scss";
 @import url("https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.2/font/bootstrap-icons.css");


### PR DESCRIPTION
Agregado componente Housekeeper-Reports que permite al usuario ama de llaves ver sus opciones para requisitar sus formularios de reporte previo y posterior y enviarlos.

- El botón de Reporte previo estará activo siempre, pues es el primer formulario.
- Cuando se haya requisitado el primer formulario y se hayan guardado cambios se habilitará el botón de Reporte posterior.
- Ya requisitados ambos reportes podrá darle clic al botón de Enviar.

<img width="302" alt="image" src="https://user-images.githubusercontent.com/99765304/171082944-4ba5658b-e236-47ac-9540-590d473fe385.png">


- También se agrega un botón para regresar al panel anterior (Actividades) y una ruta de migas con función de navegación a apartados anteriores.

