### PR TITLE
Feature/keeper posterior report

### DIFF
--- a/src/app/housekeeper/components/housekeeper-posterior-report/housekeeper-posterior-report.component.html
+++ b/src/app/housekeeper/components/housekeeper-posterior-report/housekeeper-posterior-report.component.html
@@ -1,0 +1,49 @@
+<div class="container my-5">
+  <div class="mx-4 mx-sm-auto d-flex flex-column gap-4 justify-content-center col-sm-7 col-md-6 col-lg-4 lg:p-x-6">
+
+    <h1 class="text-center fs-2 fw-normal text-primary m-0">Reporte posterior</h1>
+
+    <nav
+      style="--bs-breadcrumb-divider: url(&#34;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='currentColor' class='bi bi-chevron-right' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z'/%3E%3C/svg%3E&#34;);"
+      aria-label="breadcrumb">
+      <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item"><a routerLink="/housekeeper/menu" [queryParams]="{page: '1'}">Menú</a></li>
+        <li class="breadcrumb-item"><a routerLink="/housekeeper/activities" [queryParams]="{page: '1'}">Actividades</a></li>
+        <li class="breadcrumb-item"><a routerLink="/housekeeper/reports" [queryParams]="{id}">Reportes</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Reporte posterior</li>
+      </ol>
+    </nav>
+
+    <p>Fecha de inspección: {{myDate | date: 'EEEE, MMMM d, y' }}</p>
+
+    <form class="d-flex flex-column gap-4 needs-validation css-form" [formGroup]="housekeeperPosteriorReport" (ngSubmit)="submitForm()">
+
+      <div>
+        <label for="video" class="form-label">Resultado final</label><br>
+        <button class="btn btn-outline-primary" routerLink="/housekeeper/reports/video" [queryParams]="{id, type: 'posterior'}"><i
+            class="bi bi-camera-video-fill"></i> Tomar video</button>
+            <div class="text-danger small" *ngIf="videoError">
+              *El video es requerido.
+            </div>
+      </div>
+      <div>
+        <label for="description" class="form-label">Objetos olvidados</label>
+        <textarea class="form-control" name="description" id="description" aria-label="With textarea"
+          formControlName="description"></textarea>
+
+        <div class="text-danger small"
+          *ngIf="housekeeperPosteriorReport.get('description')?.hasError('maxlength')&& housekeeperPosteriorReport.get('description')?.touched">
+          *La descripción no debe contener mas de 100 caracteres
+        </div>
+      </div>
+
+      <div class="d-grid gap-4">
+        <input [disabled]="housekeeperPosteriorReport.invalid" type="submit" value="Guardar" class="btn btn-lg btn-primary shadow-sm">
+        <button routerLink="/housekeeper/reports" [queryParams]="{id}"
+          class="btn btn-lg btn-outline-primary shadow-sm">Cancelar</button>
+      </div>
+    </form>
+
+  </div>
+</div>
+

--- a/src/app/housekeeper/components/housekeeper-posterior-report/housekeeper-posterior-report.component.scss
+++ b/src/app/housekeeper/components/housekeeper-posterior-report/housekeeper-posterior-report.component.scss
@@ -1,0 +1,7 @@
+.css-form textarea.ng-invalid.ng-touched {
+  border : 1px solid red;
+}
+
+.css-form textarea.ng-valid.ng-touched {
+  border :  1px solid green;
+}

--- a/src/app/housekeeper/components/housekeeper-posterior-report/housekeeper-posterior-report.component.spec.ts
+++ b/src/app/housekeeper/components/housekeeper-posterior-report/housekeeper-posterior-report.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HousekeeperPosteriorReportComponent } from './housekeeper-posterior-report.component';
+
+describe('HousekeeperPosteriorReportComponent', () => {
+  let component: HousekeeperPosteriorReportComponent;
+  let fixture: ComponentFixture<HousekeeperPosteriorReportComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ HousekeeperPosteriorReportComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HousekeeperPosteriorReportComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/housekeeper/components/housekeeper-posterior-report/housekeeper-posterior-report.component.ts
+++ b/src/app/housekeeper/components/housekeeper-posterior-report/housekeeper-posterior-report.component.ts
@@ -1,0 +1,63 @@
+import { Component, OnInit } from '@angular/core';
+import { Activity } from '../../interfaces/activity.interface';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { HousekeeperActivitiesService } from '../../services/housekeeper-activities.service';
+import { ActivatedRoute, Router } from '@angular/router';
+import { ToastrService } from 'ngx-toastr';
+import { VideoCaptureService } from '../../../menu/services/video-capture.service';
+import { HousekeeperPosteriorReport } from '../../interfaces/housekeeperPosteriorReport';
+
+@Component({
+  selector: 'app-housekeeper-posterior-report',
+  templateUrl: './housekeeper-posterior-report.component.html',
+  styleUrls: ['./housekeeper-posterior-report.component.scss']
+})
+export class HousekeeperPosteriorReportComponent implements OnInit {
+
+  myDate = new Date();
+  activities!:Array<Activity>
+  videoError: boolean = false;
+  id: string = this.route.snapshot.queryParams['id']
+
+  housekeeperPosteriorReport: FormGroup = this.fb.group({
+    description: ['', [Validators.maxLength(100)]]
+  });
+
+  constructor(
+    private fb: FormBuilder,
+    private housekeeperActivitiesService: HousekeeperActivitiesService,
+    private route: ActivatedRoute,
+    private router: Router,
+    private toastService: ToastrService,
+    private videoService: VideoCaptureService
+  ) {}
+
+  ngOnInit(): void {
+    const regexp = new RegExp('^[0-9]+$');
+    if (this.id == null || !regexp.test(this.id)) {
+      this.toastService.warning('La página solicitada no existe. 😥');
+      this.router.navigate(['/housekeeper/activities'], {queryParams: { page: 1 }});
+    }
+  }
+
+  submitForm(){
+    const housekeeperPosteriorReport: HousekeeperPosteriorReport = {
+      description: this.housekeeperPosteriorReport.get('description')?.value
+    };
+    let formData: FormData = new FormData();
+    const video = this.videoService.getVideo();
+    if(video){
+      this.videoError = false;
+      formData.append("description",housekeeperPosteriorReport.description);
+      formData.append("video",video);
+
+      this.housekeeperActivitiesService.housekeeperPosteriorReportCreate(formData,this.id).subscribe(
+        resp => {
+          this.router.navigate(['/housekeeper/reports'],{queryParams: {id:this.id}});
+        }
+      )
+    }else{
+      this.videoError = true;
+    }
+  }
+}

--- a/src/app/housekeeper/housekeeper-routing.module.ts
+++ b/src/app/housekeeper/housekeeper-routing.module.ts
@@ -10,6 +10,7 @@ import { HousekeeperPreviousReportComponent } from './components/housekeeper-pre
 import { VideoFileComponent } from './components/video-file/video-file.component';
 import { CameraFilesComponent } from './components/camera-files/camera-files.component';
 import { HousekeeperReportsComponent } from './components/housekeeper-reports/housekeeper-reports.component';
+import { HousekeeperPosteriorReportComponent } from './components/housekeeper-posterior-report/housekeeper-posterior-report.component';
 
 const routes: Routes = [
   {
@@ -28,6 +29,9 @@ const routes: Routes = [
       },
       {
         path: 'reports/previous-report', component: HousekeeperPreviousReportComponent, canActivateChild: [MenuChildGuard]
+      },
+      {
+        path: 'reports/posterior-report', component: HousekeeperPosteriorReportComponent, canActivateChild: [MenuChildGuard]
       },
       {
         path:'reports/video', component: VideoFileComponent, canActivateChild: [MenuChildGuard]

--- a/src/app/housekeeper/housekeeper.module.ts
+++ b/src/app/housekeeper/housekeeper.module.ts
@@ -13,6 +13,7 @@ import { HousekeeperPreviousReportComponent } from './components/housekeeper-pre
 import { VideoFileComponent } from './components/video-file/video-file.component';
 import { CameraFilesComponent } from './components/camera-files/camera-files.component';
 import { HousekeeperReportsComponent } from './components/housekeeper-reports/housekeeper-reports.component';
+import { HousekeeperPosteriorReportComponent } from './components/housekeeper-posterior-report/housekeeper-posterior-report.component';
 
 
 @NgModule({
@@ -24,7 +25,8 @@ import { HousekeeperReportsComponent } from './components/housekeeper-reports/ho
     HousekeeperPreviousReportComponent,
     VideoFileComponent,
     CameraFilesComponent,
-    HousekeeperReportsComponent
+    HousekeeperReportsComponent,
+    HousekeeperPosteriorReportComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/housekeeper/interfaces/housekeeperPosteriorReport.ts
+++ b/src/app/housekeeper/interfaces/housekeeperPosteriorReport.ts
@@ -1,0 +1,3 @@
+export interface HousekeeperPosteriorReport{
+  description: string;
+}

--- a/src/app/housekeeper/services/housekeeper-activities.service.ts
+++ b/src/app/housekeeper/services/housekeeper-activities.service.ts
@@ -33,4 +33,13 @@ export class HousekeeperActivitiesService {
       tap(() => this.toastService.success('El reporte previo se guardó correctamente.'))
     );
   }
+
+  housekeeperPosteriorReportCreate(housekeeperPosteriorReport: FormData, id:string){
+    const query = {
+      id
+    }
+    return this.httpClient.patch(`${this.URL}posterior-report-housekeeper/update/`, housekeeperPosteriorReport,{params:query}).pipe(
+      tap(() => this.toastService.success('El reporte posterior se guardo correctamente.'))
+    );
+  }
 }


### PR DESCRIPTION
Se creó una pantalla de Reporte posterior para usuario Ama de llaves donde será capaz de registrar las condiciones posteriores a la limpieza.

<img width="301" alt="image" src="https://user-images.githubusercontent.com/99765304/172887176-6a4b0ccb-be6d-433b-bba6-d1fb37b27cf3.png">

El usuario podrá navegar en pantallas anteriores a través de una ruta de migas.
El usuario podrá ver la Fecha de inspección
El usuario dispondrá de un formulario en donde podrá requisitar la información solicitada con respecto a las condiciones de la posteriores a la limpieza:

Adjuntar un video (Requerido de máximo 15 segundos)
Breve descripción de los objetos olvidados (Opcional, máximo 100 caracteres, si excede deshabilita botón "Enviar")

<img width="299" alt="image" src="https://user-images.githubusercontent.com/99765304/172890476-abf61064-855d-4401-80cf-b53e60d734aa.png">

Cuando el formulario esté correctamente requisitado, el botón guardar se habilitará.

<img width="296" alt="image" src="https://user-images.githubusercontent.com/99765304/172891310-4dc10627-f639-4eaa-a35a-f43a69b9cff8.png">




