### PR TITLE
Feature/housekeeper amenities

### DIFF
--- a/src/app/housekeeper/components/housekeeper-modules/housekeeper-modules.component.html
+++ b/src/app/housekeeper/components/housekeeper-modules/housekeeper-modules.component.html
@@ -11,7 +11,7 @@
       </div>
       <div class="d-flex flex-column gap-4">
         <button type="button" class="btn btn-primary btn-lg" routerLink="/housekeeper/activities" [queryParams]="{page: '1'}">Actividades de limpieza</button>
-        <button type="button" class="btn btn-primary btn-lg" routerLink="/housekeeper/register" [queryParams]="{page: '1'}">Registros de amenidades</button>
+        <button type="button" class="btn btn-primary btn-lg" routerLink="/housekeeper/registers" [queryParams]="{page: '1'}">Registros de amenidades</button>
         <button type="button" class="btn btn-primary btn-lg" routerLink="/housekeeper/inventory">Inventario</button>
       </div>
   </div>

--- a/src/app/housekeeper/components/housekeeper-modules/housekeeper-modules.component.html
+++ b/src/app/housekeeper/components/housekeeper-modules/housekeeper-modules.component.html
@@ -11,7 +11,7 @@
       </div>
       <div class="d-flex flex-column gap-4">
         <button type="button" class="btn btn-primary btn-lg" routerLink="/housekeeper/activities" [queryParams]="{page: '1'}">Actividades de limpieza</button>
-        <button type="button" class="btn btn-primary btn-lg" routerLink="/housekeeper/amenityRecordsList" [queryParams]="{page: '1'}">Registros de amenidades</button>
+        <button type="button" class="btn btn-primary btn-lg" routerLink="/housekeeper/register" [queryParams]="{page: '1'}">Registros de amenidades</button>
         <button type="button" class="btn btn-primary btn-lg" routerLink="/housekeeper/inventory">Inventario</button>
       </div>
   </div>

--- a/src/app/housekeeper/components/housekeeper-modules/housekeeper-modules.component.html
+++ b/src/app/housekeeper/components/housekeeper-modules/housekeeper-modules.component.html
@@ -11,7 +11,7 @@
       </div>
       <div class="d-flex flex-column gap-4">
         <button type="button" class="btn btn-primary btn-lg" routerLink="/housekeeper/activities" [queryParams]="{page: '1'}">Actividades de limpieza</button>
-        <button type="button" class="btn btn-primary btn-lg" routerLink="/housekeeper/register" [queryParams]="{page: '1'}">Registros de amenidades</button>
+        <button type="button" class="btn btn-primary btn-lg" routerLink="/housekeeper/amenityRecordsList" [queryParams]="{page: '1'}">Registros de amenidades</button>
         <button type="button" class="btn btn-primary btn-lg" routerLink="/housekeeper/inventory">Inventario</button>
       </div>
   </div>

--- a/src/app/housekeeper/components/register/register.component.html
+++ b/src/app/housekeeper/components/register/register.component.html
@@ -1,0 +1,69 @@
+<div class="container my-5" >
+  <div class="mx-4 mx-sm-auto d-flex flex-column gap-4 justify-content-center col-sm-7 col-md-6 col-lg-4 lg:p-x-6">
+
+    <h1 class="text-center fs-2 fw-normal text-primary m-0">Registrar amenidades</h1>
+
+    <nav
+      style="--bs-breadcrumb-divider: url(&#34;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='currentColor' class='bi bi-chevron-right' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z'/%3E%3C/svg%3E&#34;);"
+      aria-label="breadcrumb">
+      <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item"><a routerLink="/housekeeper/menu" [queryParams]="{page: '1'}">Menú</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Registrar amenidades</li>
+      </ol>
+    </nav>
+
+    <p>Stock inicial: 30</p>
+
+    <form class="d-flex flex-column gap-4 needs-validation css-form" [formGroup]="registerAmenidades" (ngSubmit)="onSubmit()">
+
+      <div >
+        <label for="entrega" class="form-label">Entrega</label>
+        <select #entrega (change)='onOptionsSelected(entrega.value)' id="entrega" class="form-select" aria-label="Default select example">
+          <option hidden selected>Selecciona una opción</option>
+          <option value="Ama de llaves">Ama de llaves</option>
+          <option value="Camarista">Camarista</option>
+        </select>
+      </div>
+
+      <div>
+        <label  for="recibe" class="form-label">Recibe</label>
+        <select [disabled]="is_edit" #recibe (change)='option(recibe.value)'  id="recibe" class="form-select" aria-label="Default select example">
+          <option hidden selected>Selecciona una opción</option>
+          <option *ngFor="let maid of data" value="{{maid.id}}">{{maid.name}}</option>
+        </select>
+      </div>
+
+
+      <div>
+        <label for="video" class="form-label">Amenidades</label>
+        <div>
+          <label for="redacción" class="col-4 col-form-label">Toallas</label>
+          <div>
+            <input formControlName="toallas" type="number" min="0" step="1" value="0" class="form-control">
+          </div>
+        </div>
+
+        <div>
+          <label for="redacción" class="col-4 col-form-label">Sábanas</label>
+          <div>
+            <input formControlName="sabanas" type="number" min="0" step="1" value="0" class="form-control">
+          </div>
+        </div>
+
+        <div>
+          <label for="redacción" class="col-4 col-form-label">Cobijas</label>
+          <div>
+            <input formControlName="cobija" type="number" min="0" step="1" value="0" class="form-control">
+          </div>
+        </div>
+      </div>
+
+      <div class="d-grid gap-4">
+        <input type="submit" value="Guardar" class="btn btn-lg btn-primary shadow-sm">
+        <button routerLink="/housekeeper/amenityRecordsList" class="btn btn-lg btn-outline-primary shadow-sm">Cancelar</button>
+      </div>
+
+    </form>
+
+  </div>
+</div>

--- a/src/app/housekeeper/components/register/register.component.html
+++ b/src/app/housekeeper/components/register/register.component.html
@@ -27,7 +27,7 @@
 
       <div>
         <label  for="recibe" class="form-label">Recibe</label>
-        <select [disabled]="is_edit" #recibe (change)='option(recibe.value)'  id="recibe" class="form-select" aria-label="Default select example">
+        <select [disabled]="isEdit" #recibe (change)='option(recibe.value)'  id="recibe" class="form-select" aria-label="Default select example">
           <option hidden selected>Selecciona una opción</option>
           <option *ngFor="let maid of data" value="{{maid.id}}">{{maid.name}}</option>
         </select>
@@ -60,7 +60,7 @@
 
       <div class="d-grid gap-4">
         <input type="submit" value="Guardar" class="btn btn-lg btn-primary shadow-sm">
-        <button routerLink="/housekeeper/amenityRecordsList" class="btn btn-lg btn-outline-primary shadow-sm">Cancelar</button>
+        <button routerLink="/housekeeper/register" class="btn btn-lg btn-outline-primary shadow-sm">Cancelar</button>
       </div>
 
     </form>

--- a/src/app/housekeeper/components/register/register.component.html
+++ b/src/app/housekeeper/components/register/register.component.html
@@ -8,6 +8,7 @@
       aria-label="breadcrumb">
       <ol class="breadcrumb mb-0">
         <li class="breadcrumb-item"><a routerLink="/housekeeper/menu" [queryParams]="{page: '1'}">Menú</a></li>
+        <li class="breadcrumb-item"><a routerLink="/housekeeper/registers" [queryParams]="{page: '1'}">Registros de amenidades</a></li>
         <li class="breadcrumb-item active" aria-current="page">Registrar amenidades</li>
       </ol>
     </nav>
@@ -60,7 +61,7 @@
 
       <div class="d-grid gap-4">
         <input type="submit" value="Guardar" class="btn btn-lg btn-primary shadow-sm">
-        <button routerLink="/housekeeper/register" class="btn btn-lg btn-outline-primary shadow-sm">Cancelar</button>
+        <button routerLink="/housekeeper/registers" class="btn btn-lg btn-outline-primary shadow-sm">Cancelar</button>
       </div>
 
     </form>

--- a/src/app/housekeeper/components/register/register.component.spec.ts
+++ b/src/app/housekeeper/components/register/register.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RegisterComponent } from './register.component';
+
+describe('RegisterComponent', () => {
+  let component: RegisterComponent;
+  let fixture: ComponentFixture<RegisterComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ RegisterComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RegisterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/housekeeper/components/register/register.component.ts
+++ b/src/app/housekeeper/components/register/register.component.ts
@@ -1,7 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { ChamberMaid } from '../../interfaces/registerAmenidades.interface';
-import { Router, ActivatedRoute } from '@angular/router';
-import { ToastrService } from 'ngx-toastr';
 import { FormGroup, FormBuilder } from '@angular/forms';
 import { Register } from '../../interfaces/registerAmenidades.interface';
 import { ProfileService } from 'src/app/auth/services/profile.service';
@@ -21,8 +19,7 @@ export class RegisterComponent implements OnInit {
   registerAmenidades!: FormGroup;
 
 
-  constructor(private router: Router, private route: ActivatedRoute, private toastService: ToastrService,
-    private housekeeperAmenidades: HousekeeperAmenidadesService, private fb: FormBuilder, private profileService: ProfileService) { }
+  constructor(private housekeeperAmenidades: HousekeeperAmenidadesService, private fb: FormBuilder, private profileService: ProfileService) { }
 
   ngOnInit(): void {
     this.registerAmenidades = this.fb.group({
@@ -77,13 +74,8 @@ export class RegisterComponent implements OnInit {
         }
       ]
     }
-    this.housekeeperAmenidades.sendInfo(register).subscribe(
-      resp => {
-        this.router.navigate(['/housekeeper/registers']);
-        this.toastService.success('¡Registro guardado exitosamente!');
 
-      }
-    )
+    this.housekeeperAmenidades.sendInfo(register).subscribe();
 
   }
 
@@ -92,6 +84,5 @@ export class RegisterComponent implements OnInit {
       .subscribe(data => {
         this.data = data
       });
-
   }
 }

--- a/src/app/housekeeper/components/register/register.component.ts
+++ b/src/app/housekeeper/components/register/register.component.ts
@@ -79,7 +79,7 @@ export class RegisterComponent implements OnInit {
     }
     this.housekeeperAmenidades.sendInfo(register).subscribe(
       resp => {
-        this.router.navigate(['/housekeeper/register']);
+        this.router.navigate(['/housekeeper/registers']);
         this.toastService.success('¡Registro guardado exitosamente!');
 
       }

--- a/src/app/housekeeper/components/register/register.component.ts
+++ b/src/app/housekeeper/components/register/register.component.ts
@@ -1,0 +1,117 @@
+import { Component, OnInit, Input} from '@angular/core';
+import { ChamberMaid} from '../../interfaces/registerAmenidades.interface';
+import { Router, ActivatedRoute } from '@angular/router';
+import { ToastrService } from 'ngx-toastr';
+import { FormGroup, FormBuilder} from '@angular/forms';
+import { Register } from '../../interfaces/registerAmenidades.interface';
+import { ProfileService } from 'src/app/auth/services/profile.service';
+import { HousekeeperAmenidadesService } from '../../services/housekeeper-amenidades.service';
+
+@Component({
+  selector: 'app-register',
+  templateUrl: './register.component.html',
+  styleUrls: ['./register.component.scss']
+})
+export class RegisterComponent implements OnInit {
+  @Input() maidList!: Array<Body>;
+  public data: ChamberMaid[] = []
+  actualPage: number = this.route.snapshot.queryParams['page'];
+  searchTxt: string = '';
+  is_edit!: boolean;
+  profile = this.profileService.showData();
+
+  registerAmenidades!: FormGroup;
+
+
+  constructor(private router: Router, private route: ActivatedRoute, private toastService: ToastrService,
+    private housekeeperAmenidades: HousekeeperAmenidadesService, private fb: FormBuilder, private profileService: ProfileService) { this.is_edit = true; }
+
+  ngOnInit(): void {
+    this.registerAmenidades = this.fb.group({
+      id: [this.profile.id],
+      type: ['Salida'],
+      name: [this.profile.name],
+      toallas: [0],
+      sabanas: [0],
+      cobija: [0]
+    })
+  }
+
+  onOptionsSelected(value: string) {
+    if (value == 'Camarista') {
+      this.is_edit = false;
+      this.getMaid();
+    } else {
+      this.is_edit = true;
+      this.data = [];
+
+    }
+  }
+
+  option(id: string) {
+    const idMaid = this.data.findIndex(item => item.id == Number(id));
+    const maid = this.data[idMaid];
+    this.registerAmenidades.patchValue({ id: maid.id, name: maid.name })
+  }
+
+
+  onSubmit() {
+    const register : Register = {
+      id:this.registerAmenidades.get('id')?.value,
+      type:this.registerAmenidades.get('type')?.value,
+      name:this.registerAmenidades.get('name')?.value,
+
+      amenidades: [
+        {
+          name: 'toallas',
+          quantity: this.registerAmenidades.get('toallas')?.value
+        },
+        {
+          name: 'sabanas',
+          quantity: this.registerAmenidades.get('sabanas')?.value
+        },
+        {
+          name: 'cobija',
+          quantity: this.registerAmenidades.get('cobija')?.value
+        }
+      ]
+    }
+    this.housekeeperAmenidades.sendInfo(register).subscribe(
+      resp => {
+        this.router.navigate(['/housekeeper/amenityRecordsList']);
+      }
+    )
+
+  }
+
+  pageSelected(page: number): void {
+    this.router.navigate([],
+      {
+        relativeTo: this.route,
+        queryParams: { page: page },
+        queryParamsHandling: 'merge'
+      });
+    this.actualPage = page;
+    this.getMaid();
+  }
+
+
+  getMaid(): void {
+    this.housekeeperAmenidades.getMaid()
+      .subscribe(data => {
+        console.log(data)
+        this.data = data
+        console.log(data)
+      });
+
+  }
+
+  alertMessagePage(): void {
+    this.toastService.warning('La página solicitada no existe. 😥');
+    this.pageSelected(1);
+  }
+
+  submitForm() {
+  }
+
+}

--- a/src/app/housekeeper/components/register/register.component.ts
+++ b/src/app/housekeeper/components/register/register.component.ts
@@ -1,8 +1,8 @@
-import { Component, OnInit, Input} from '@angular/core';
-import { ChamberMaid} from '../../interfaces/registerAmenidades.interface';
+import { Component, OnInit, Input } from '@angular/core';
+import { ChamberMaid } from '../../interfaces/registerAmenidades.interface';
 import { Router, ActivatedRoute } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
-import { FormGroup, FormBuilder} from '@angular/forms';
+import { FormGroup, FormBuilder } from '@angular/forms';
 import { Register } from '../../interfaces/registerAmenidades.interface';
 import { ProfileService } from 'src/app/auth/services/profile.service';
 import { HousekeeperAmenidadesService } from '../../services/housekeeper-amenidades.service';
@@ -14,15 +14,15 @@ import { HousekeeperAmenidadesService } from '../../services/housekeeper-amenida
 })
 export class RegisterComponent implements OnInit {
   @Input() maidList!: Array<Body>;
-  public data: ChamberMaid[] = []
-  is_edit!: boolean;
+  data: ChamberMaid[] = []
+  isEdit: boolean = true;
   profile = this.profileService.showData();
 
   registerAmenidades!: FormGroup;
 
 
   constructor(private router: Router, private route: ActivatedRoute, private toastService: ToastrService,
-    private housekeeperAmenidades: HousekeeperAmenidadesService, private fb: FormBuilder, private profileService: ProfileService) { this.is_edit = true; }
+    private housekeeperAmenidades: HousekeeperAmenidadesService, private fb: FormBuilder, private profileService: ProfileService) { }
 
   ngOnInit(): void {
     this.registerAmenidades = this.fb.group({
@@ -37,12 +37,15 @@ export class RegisterComponent implements OnInit {
 
   onOptionsSelected(value: string) {
     if (value == 'Camarista') {
-      this.is_edit = false;
+      this.isEdit = false;
       this.getMaid();
     } else {
-      this.is_edit = true;
+      this.isEdit = true;
       this.data = [];
-
+      this.registerAmenidades.patchValue({
+        id: [this.profile.id],
+        name: [this.profile.name]
+      })
     }
   }
 
@@ -54,10 +57,10 @@ export class RegisterComponent implements OnInit {
 
 
   onSubmit() {
-    const register : Register = {
-      id:this.registerAmenidades.get('id')?.value,
-      type:this.registerAmenidades.get('type')?.value,
-      name:this.registerAmenidades.get('name')?.value,
+    const register: Register = {
+      id: this.registerAmenidades.get('id')?.value,
+      type: this.registerAmenidades.get('type')?.value,
+      name: this.registerAmenidades.get('name')?.value,
 
       amenidades: [
         {
@@ -74,9 +77,12 @@ export class RegisterComponent implements OnInit {
         }
       ]
     }
+    console.log(register)
     this.housekeeperAmenidades.sendInfo(register).subscribe(
       resp => {
-        this.router.navigate(['/housekeeper/amenityRecordsList']);
+        this.router.navigate(['/housekeeper/register']);
+        this.toastService.success('¡Registo guardado exitosamente!');
+
       }
     )
 

--- a/src/app/housekeeper/components/register/register.component.ts
+++ b/src/app/housekeeper/components/register/register.component.ts
@@ -15,8 +15,6 @@ import { HousekeeperAmenidadesService } from '../../services/housekeeper-amenida
 export class RegisterComponent implements OnInit {
   @Input() maidList!: Array<Body>;
   public data: ChamberMaid[] = []
-  actualPage: number = this.route.snapshot.queryParams['page'];
-  searchTxt: string = '';
   is_edit!: boolean;
   profile = this.profileService.showData();
 
@@ -84,34 +82,11 @@ export class RegisterComponent implements OnInit {
 
   }
 
-  pageSelected(page: number): void {
-    this.router.navigate([],
-      {
-        relativeTo: this.route,
-        queryParams: { page: page },
-        queryParamsHandling: 'merge'
-      });
-    this.actualPage = page;
-    this.getMaid();
-  }
-
-
   getMaid(): void {
     this.housekeeperAmenidades.getMaid()
       .subscribe(data => {
-        console.log(data)
         this.data = data
-        console.log(data)
       });
 
   }
-
-  alertMessagePage(): void {
-    this.toastService.warning('La página solicitada no existe. 😥');
-    this.pageSelected(1);
-  }
-
-  submitForm() {
-  }
-
 }

--- a/src/app/housekeeper/components/register/register.component.ts
+++ b/src/app/housekeeper/components/register/register.component.ts
@@ -77,11 +77,10 @@ export class RegisterComponent implements OnInit {
         }
       ]
     }
-    console.log(register)
     this.housekeeperAmenidades.sendInfo(register).subscribe(
       resp => {
         this.router.navigate(['/housekeeper/register']);
-        this.toastService.success('¡Registo guardado exitosamente!');
+        this.toastService.success('¡Registro guardado exitosamente!');
 
       }
     )

--- a/src/app/housekeeper/housekeeper-routing.module.ts
+++ b/src/app/housekeeper/housekeeper-routing.module.ts
@@ -10,6 +10,7 @@ import { HousekeeperPreviousReportComponent } from './components/housekeeper-pre
 import { VideoFileComponent } from './components/video-file/video-file.component';
 import { CameraFilesComponent } from './components/camera-files/camera-files.component';
 import { HousekeeperReportsComponent } from './components/housekeeper-reports/housekeeper-reports.component';
+import { RegisterComponent } from './components/register/register.component';
 
 const routes: Routes = [
   {
@@ -37,6 +38,9 @@ const routes: Routes = [
       },
       {
         path: 'reports', component: HousekeeperReportsComponent, canActivateChild: [MenuChildGuard]
+      },
+      {
+        path: 'register', component: RegisterComponent, canActivateChild: [MenuChildGuard]
       }
     ]
   }

--- a/src/app/housekeeper/housekeeper-routing.module.ts
+++ b/src/app/housekeeper/housekeeper-routing.module.ts
@@ -40,7 +40,7 @@ const routes: Routes = [
         path: 'reports', component: HousekeeperReportsComponent, canActivateChild: [MenuChildGuard]
       },
       {
-        path: 'AmenitiesOutIn', component: RegisterComponent, canActivateChild: [MenuChildGuard]
+        path: 'amenitiesOutIn', component: RegisterComponent, canActivateChild: [MenuChildGuard]
       }
     ]
   }

--- a/src/app/housekeeper/housekeeper-routing.module.ts
+++ b/src/app/housekeeper/housekeeper-routing.module.ts
@@ -40,7 +40,7 @@ const routes: Routes = [
         path: 'reports', component: HousekeeperReportsComponent, canActivateChild: [MenuChildGuard]
       },
       {
-        path: 'register', component: RegisterComponent, canActivateChild: [MenuChildGuard]
+        path: 'AmenitiesOutIn', component: RegisterComponent, canActivateChild: [MenuChildGuard]
       }
     ]
   }

--- a/src/app/housekeeper/housekeeper.module.ts
+++ b/src/app/housekeeper/housekeeper.module.ts
@@ -13,6 +13,8 @@ import { HousekeeperPreviousReportComponent } from './components/housekeeper-pre
 import { VideoFileComponent } from './components/video-file/video-file.component';
 import { CameraFilesComponent } from './components/camera-files/camera-files.component';
 import { HousekeeperReportsComponent } from './components/housekeeper-reports/housekeeper-reports.component';
+import { RegisterComponent } from './components/register/register.component';
+
 
 
 @NgModule({
@@ -24,7 +26,8 @@ import { HousekeeperReportsComponent } from './components/housekeeper-reports/ho
     HousekeeperPreviousReportComponent,
     VideoFileComponent,
     CameraFilesComponent,
-    HousekeeperReportsComponent
+    HousekeeperReportsComponent,
+    RegisterComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/housekeeper/interfaces/registerAmenidades.interface.ts
+++ b/src/app/housekeeper/interfaces/registerAmenidades.interface.ts
@@ -1,0 +1,22 @@
+export interface Maid {
+  status: number;
+  message: string;
+  body: ChamberMaid[];
+}
+export interface ChamberMaid {
+  id: number;
+  name: string;
+  firstSurname: string;
+}
+
+export interface Register {
+  id: number;
+  type: string;
+  name: string;
+  amenidades: Amenidad[];
+}
+
+export interface Amenidad {
+  name: string;
+  quantity: number;
+}

--- a/src/app/housekeeper/services/housekeeper-amenidades.service.ts
+++ b/src/app/housekeeper/services/housekeeper-amenidades.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { environment } from '../../../environments/environment';
+import { Observable } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
+import { map } from 'rxjs/operators';
+import { ChamberMaid, Maid } from '../interfaces/registerAmenidades.interface';
+import { Register } from '../interfaces/registerAmenidades.interface';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class HousekeeperAmenidadesService {
+
+  private readonly URL: string = environment.URL;
+
+  constructor(private httpClient: HttpClient) { }
+
+  getMaid(): Observable<ChamberMaid[]> {
+    return this.httpClient.get<Maid>(`${this.URL}maid/list`).pipe(
+      map((response) => {
+        return response.body;
+      })
+    );
+  }
+
+  sendInfo(register: Register){
+    return this.httpClient.post(`${this.URL}housekeeper/register`, register).pipe(
+    );
+  }
+}

--- a/src/app/housekeeper/services/housekeeper-amenidades.service.ts
+++ b/src/app/housekeeper/services/housekeeper-amenidades.service.ts
@@ -2,9 +2,11 @@ import { Injectable } from '@angular/core';
 import { environment } from '../../../environments/environment';
 import { Observable } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
-import { map } from 'rxjs/operators';
+import { map, tap } from 'rxjs/operators';
 import { ChamberMaid, Maid } from '../interfaces/registerAmenidades.interface';
 import { Register } from '../interfaces/registerAmenidades.interface';
+import { Router } from '@angular/router';
+import { ToastrService } from 'ngx-toastr';
 
 @Injectable({
   providedIn: 'root'
@@ -13,7 +15,7 @@ export class HousekeeperAmenidadesService {
 
   private readonly URL: string = environment.URL;
 
-  constructor(private httpClient: HttpClient) { }
+  constructor(private httpClient: HttpClient, private router:Router, private toastService: ToastrService) { }
 
   getMaid(): Observable<ChamberMaid[]> {
     return this.httpClient.get<Maid>(`${this.URL}maid/list`).pipe(
@@ -24,7 +26,10 @@ export class HousekeeperAmenidadesService {
   }
 
   sendInfo(register: Register){
-    return this.httpClient.post(`${this.URL}housekeeper/register`, register).pipe(
-    );
+    return this.httpClient.post(`${this.URL}housekeeper/register`, register).pipe(tap(() => {
+      this.router.navigate(['/housekeeper/registers']);
+      this.toastService.success('¡Registro guardado exitosamente!');
+    }) )
   }
+
 }


### PR DESCRIPTION
Agregado componente para registrar las entradas y salidas de las amenidades que tiene a cargo la ama de llaves.
El usuario puede navegar a otros módulos con la ruta de migas además dispone de un primer select que le permite seleccionar el usuario que hace entrega de las amenidades , en el segundo select selecciona al usuario que recibe dichas amenidades este se habilita cuando en el primer select se haya seleccionado el tipo de usuario 'camarista' 
![image](https://user-images.githubusercontent.com/79349436/172993183-483bf60c-d754-492d-a1d9-60b2910eac99.png)
![172993437-7cb7cdcc-ea21-4516-8438-6f47e3b502d2](https://user-images.githubusercontent.com/79349436/172993635-5356d6da-beac-489a-876b-134546390d82.png)


El usuario indica la cantidad de cada amenidad que entrega o recibe
![image](https://user-images.githubusercontent.com/79349436/172993391-77825d2f-29a1-4868-b4ee-81dd02abc9b9.png)

Cuando el usuario haga clic en el boton guardar la informacion se manda a la api y la aplicacion redirije al usuario a una pantalla de lista de registros

![localhost_4200_housekeeper_register_page=1(iPhone SE)](https://user-images.githubusercontent.com/79349436/172993756-d279269c-b007-40cf-ba7c-dc58c4df7e1c.png)

